### PR TITLE
Extract utils and add Jest tests

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,23 @@
+import { formatCurrency, formatDate } from '../utils.js';
+
+describe('formatCurrency', () => {
+  test('formats number to KRW currency', () => {
+    expect(formatCurrency(1000)).toBe('₩1,000');
+  });
+});
+
+describe('formatDate', () => {
+  test('formats ISO string correctly', () => {
+    const result = formatDate('2024-06-01T12:34:56Z');
+    expect(result).toBe('2024-06-01 12:34');
+  });
+
+  test('returns placeholder for falsy values', () => {
+    expect(formatDate(null)).toBe('날짜 정보 없음');
+  });
+
+  test('handles objects with toDate method', () => {
+    const obj = { toDate: () => new Date('2024-06-01T00:00:00Z') };
+    expect(formatDate(obj)).toBe('2024-06-01 00:00');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -602,6 +602,7 @@
         limit,
         deleteField
     } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+    import { formatCurrency, formatDate } from './utils.js';
 
     const firebaseConfig = {
       apiKey: "AIzaSyDCeJPDQUNi-KmJ9DhkTRIu-9t2PGZCpt0",
@@ -636,15 +637,7 @@
     const stockChartInstances = {};
 
     // --- Utility Functions ---
-    const formatCurrency = (amount) => new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
-    const formatDate = (date) => {
-        if (!date) return '날짜 정보 없음';
-        if (date instanceof Timestamp) { 
-            date = date.toDate();
-        }
-        const d = new Date(date);
-        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
-    };
+    // formatCurrency and formatDate are imported from utils.js
      const isSameDay = (date1, date2) => {
         if (!date1 || !date2) return false;
         const d1 = (date1 instanceof Timestamp) ? date1.toDate() : new Date(date1);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mansungcoin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,14 @@
+export const formatCurrency = (amount) =>
+  new Intl.NumberFormat('ko-KR', {
+    style: 'currency',
+    currency: 'KRW'
+  }).format(amount);
+
+export const formatDate = (date) => {
+  if (!date) return '날짜 정보 없음';
+  if (date instanceof Date === false && typeof date.toDate === 'function') {
+    date = date.toDate();
+  }
+  const d = new Date(date);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+};


### PR DESCRIPTION
## Summary
- modularize common helpers into `utils.js`
- import new helper module in `index.html`
- configure Jest and add first unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8a73493c832e8da3ec1101a7eda1