### PR TITLE
Improve login error and store instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# MansungCoin
+
+This project is a simple economy simulation for students. All data is stored in Firebase.
+
+## Running Locally
+
+1. Install dependencies (optional for tests):
+   ```
+npm install
+```
+   If you cannot access the npm registry, you may skip this step and run only the static HTML.
+2. Open `index.html` in a browser. The app expects Firebase to be reachable. You should replace the Firebase configuration in `index.html` with your own project settings.
+
+## Login Troubleshooting
+
+If login fails with a network error, ensure your internet connection is available. The app now displays a clearer message for `auth/network-request-failed` errors.
+
+## Store Feature
+
+Teachers can add new products via the **상점** page. When no items exist, a helpful message is shown explaining how to add items. Ensure your user has the role `teacher` in Firestore to see the `+ 상품 추가` button.

--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,7 @@
             case 'auth/email-already-in-use': return '이미 사용 중인 이메일 주소입니다.';
             case 'auth/weak-password': return '비밀번호는 6자 이상이어야 합니다.';
             case 'auth/operation-not-allowed': return '이메일/비밀번호 로그인이 활성화되지 않았습니다.';
+            case 'auth/network-request-failed': return '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.';
             default: return errorCode;
         }
     }
@@ -2125,7 +2126,13 @@
     // --- Store Logic ---
     function renderStoreItems() {
         if (!storeItemsData || storeItemsData.length === 0) {
-            storeItemsContainer.innerHTML = '<p class="text-center text-stone-500">상점이 비어있습니다.</p>';
+            const msg = (currentUserData && currentUserData.role === 'teacher')
+                ? '상점이 비어있습니다. 우측 상단의 "+ 상품 추가" 버튼으로 상품을 등록하세요.'
+                : '상점이 비어있습니다. 나중에 다시 확인해주세요.';
+            storeItemsContainer.innerHTML = `<p class="text-center text-stone-500">${msg}</p>`;
+            if (currentUserData && currentUserData.role === 'teacher') {
+                addStoreItemBtn.classList.remove('hidden');
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- clarify network error during login
- show helpful message when store is empty
- document setup instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc2f63f2c832e9eed287ea310ddbe