### PR TITLE
Fix login redirect timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1339,7 +1339,7 @@
         authErrorEl.classList.add('hidden');
         try {
             await signInWithEmailAndPassword(auth, email, password);
-            showSection('dashboard');
+            showSection('dashboard', true);
             loginForm.reset();
         } catch (error) {
             console.warn("Standard login failed, trying temporary password:", error.code);
@@ -1364,7 +1364,7 @@
                                 adminNavLink.classList.remove('hidden');
                                 adminDivider.classList.remove('hidden');
                             }
-                            showSection('dashboard');
+                            showSection('dashboard', true);
                             showInfoModal("임시 비밀번호 로그인 성공", "보안을 위해 즉시 '환경 설정'에서 새 비밀번호로 변경해주세요!");
                             loginForm.reset();
                             return;


### PR DESCRIPTION
## Summary
- force dashboard section to display immediately on successful sign in
- do the same for temporary password logins

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc8b23134832eae372a116ba840ee