### PR TITLE
Improve Firebase config warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ This project is a simple economy simulation for students. All data is stored in 
 npm install
 ```
    If you cannot access the npm registry, you may skip this step and run only the static HTML.
-2. Open `index.html` in a browser. The app expects Firebase to be reachable. You should replace the Firebase configuration in `index.html` with your own project settings.
+2. Open `index.html` in a browser. The app expects Firebase to be reachable.
+   **Important:** replace the sample `firebaseConfig` object in `index.html` with
+   your own Firebase project credentials. The app now warns if the default
+   configuration is still present.
 
 ## Login Troubleshooting
 
-If login fails with a network error, ensure your internet connection is available. The app now displays a clearer message for `auth/network-request-failed` errors.
+If login fails with a network error, ensure your internet connection is available. A warning will also appear if the Firebase configuration was not replaced, which can cause `auth/invalid-api-key` errors during login.
 
 ## Store Feature
 

--- a/index.html
+++ b/index.html
@@ -971,6 +971,12 @@
     const closeStoreItemModalBtn = document.getElementById('closeStoreItemModalBtn');
     const storeItemForm = document.getElementById('storeItemForm');
 
+    // Warn if the sample Firebase configuration has not been replaced
+    if (firebaseConfig.projectId === 'mansungcoin-c6e06') {
+        showInfoModal('Firebase 설정 필요',
+            'index.html의 firebaseConfig를 자신의 Firebase 프로젝트 정보로 교체해야 로그인이 가능합니다.');
+    }
+
 
     // --- Navigation ---
     function showSection(sectionId, forceShow = false) {
@@ -1421,6 +1427,8 @@
             case 'auth/weak-password': return '비밀번호는 6자 이상이어야 합니다.';
             case 'auth/operation-not-allowed': return '이메일/비밀번호 로그인이 활성화되지 않았습니다.';
             case 'auth/network-request-failed': return '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.';
+            case 'auth/invalid-api-key':
+                return 'Firebase API 키가 올바르지 않습니다. index.html의 firebaseConfig를 자신의 설정으로 교체했는지 확인하세요.';
             default: return errorCode;
         }
     }


### PR DESCRIPTION
## Summary
- notify users if the bundled Firebase config was not replaced
- map `auth/invalid-api-key` to a helpful Korean message
- clarify in README that `firebaseConfig` must be replaced

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcc220c58832e88de372be29fe42a