### PR TITLE
Improve admin index error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ If login fails with a network error, ensure your internet connection is availabl
 ## Store Feature
 
 Teachers can add new products via the **상점** page. When no items exist, a helpful message is shown explaining how to add items. Ensure your user has the role `teacher` in Firestore to see the `+ 상품 추가` button.
+
+## Firestore Index Setup
+
+The admin page's **선행 승인 관리** section queries across all users' `deeds` collections
+filtered by `status` and sorted by `date`. Firestore requires a composite index
+for this query. Create it from the Firebase console under **Firestore
+Database → Indexes** with the following settings:
+
+```
+Collection Group: deeds
+Fields: status (Ascending), date (Ascending)
+```
+
+Once the index is built, reloading the admin page will display the pending deeds
+correctly.

--- a/index.html
+++ b/index.html
@@ -589,7 +589,12 @@
             });
         } catch (error) {
             console.error('Error loading deeds for admin:', error);
-            adminDeedApprovalListEl.innerHTML = '<p class="text-red-500">선행 목록 로드 실패.</p>';
+            if (error.code === 'failed-precondition' && /index/i.test(error.message)) {
+                adminDeedApprovalListEl.innerHTML =
+                    '<p class="text-red-500">선행 목록 로드 실패: Firestore 색인이 필요합니다. README의 "Firestore Index Setup" 절을 참고하세요.</p>';
+            } else {
+                adminDeedApprovalListEl.innerHTML = '<p class="text-red-500">선행 목록 로드 실패.</p>';
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- document required Firestore composite index for admin deeds list
- show user-friendly message when index is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fee362644832e8c1db6699f3869c4