### PR TITLE
Fix admin permission messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ Fields: status (Ascending), date (Ascending)
 
 Once the index is built, reloading the admin page will display the pending deeds
 correctly.
+
+## Admin Access Permissions
+
+Even with the index in place, the teacher account must have permission to read
+all students' `deeds` documents. Check your Firestore security rules so that a
+user whose `role` field is `teacher` can read from the `deeds` collection group.
+If this permission is missing, the admin page will show a "permission-denied"
+error when loading the approval list.

--- a/index.html
+++ b/index.html
@@ -589,7 +589,10 @@
             });
         } catch (error) {
             console.error('Error loading deeds for admin:', error);
-            if (error.code === 'failed-precondition' && /index/i.test(error.message)) {
+            if (error.code === 'permission-denied') {
+                adminDeedApprovalListEl.innerHTML =
+                    '<p class="text-red-500">선행 목록 로드 실패: Firestore 규칙에서 teacher 권한의 읽기 권한을 확인하세요.</p>';
+            } else if (error.code === 'failed-precondition' && /index/i.test(error.message)) {
                 adminDeedApprovalListEl.innerHTML =
                     '<p class="text-red-500">선행 목록 로드 실패: Firestore 색인이 필요합니다. README의 "Firestore Index Setup" 절을 참고하세요.</p>';
             } else {


### PR DESCRIPTION
## Summary
- warn if admin page can't load deeds because of missing permissions
- document required Firestore rules for teacher accounts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410e137ae0832e8f622cb744d4c58c